### PR TITLE
Touch up --help output.

### DIFF
--- a/app/Args.hs
+++ b/app/Args.hs
@@ -53,13 +53,13 @@ envopts = [Option []    ["[no-]strict"] (BoolArg Strict) "[DON'T] Require all ty
            Option []    ["rename"] (ReqArg Rename "\"OLD NEW\"") "Replace identifier."]
 
 cmnopts :: [OptDescr CommonOption]
-cmnopts = [Option []    ["[no-]logevent"] (BoolOptArg LogEvent "EVENT") "[DON'T] Enable event tracing.",
-           Option []    ["[no-]logstate"] (BoolOptArg LogState "STATE") "[DON'T] Enable state tracing.",
+cmnopts = [Option []    ["[no-]logevent"] (BoolOptArg LogEvent "EVENT") "[DON'T] Enable event tracing where EVENT is a fully qualified <state-machine>.<event> name.",
+           Option []    ["[no-]logstate"] (BoolOptArg LogState "STATE") "[DON'T] Enable state tracing where STATE is a fully qualified <state-machine>.<state> name.",
            Option []    ["[no-]debug"] (BoolArg Debug) "[DON'T] Generate debugging information."]
 
 deprecated_c_no_debug :: [OptDescr CommonOption]
 deprecated_c_no_debug =
-          [Option []    ["no-debug"] (BoolArg Debug) "[DEPRECATED] Don't generate debugging information."]
+          [Option []    ["no-debug"] (BoolArg Debug) "(DEPRECATED) Don't generate debugging information."]
 
 data Options = SystemOption SystemOption | EnvmntOption EnvmntOption | CommonOption CommonOption | GraphVizOption GraphVizOption | CStaticOption CStaticOption
     deriving (Show, Eq)

--- a/src/Language/Smudge/Backends/GraphViz.hs
+++ b/src/Language/Smudge/Backends/GraphViz.hs
@@ -153,7 +153,7 @@ instance Backend GraphVizOption where
     options = ("dot",
                [Option [] ["fmt"] (ReqArg (Format . read) "FORMAT")
                  ("GraphViz output format.  Options: " ++
-                  (intercalate "," $ map show outputFormats)),
+                  (intercalate ", " $ map show outputFormats)),
                 Option [] ["o"] (ReqArg OutFile "FILE")
                  "The name of the target file if not derived from source file.",
                 Option [] ["no-se"] (BoolArg RenderSideEffects)


### PR DESCRIPTION
Specified that STATE and EVENT are fully qualified in the --[no-]log*
switches.  Wrapped the output to 79 columns. The 43 is hard coded for
now, but should ultimately be calculated from the max width of the
long options.